### PR TITLE
fix security vulnerability

### DIFF
--- a/junos-ez-stdlib.gemspec
+++ b/junos-ez-stdlib.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.12'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rubocop', '~> 0.42.0'
+  spec.add_development_dependency 'rubocop', '~> 0.49.0'
 end


### PR DESCRIPTION
fix below warning from github
```
We found a potential security vulnerability in one of your dependencies.
A dependency defined in ./junos-ez-stdlib.gemspec has known security vulnerabilities and should be updated.
```